### PR TITLE
Add ability to set the random seed (to make results deterministic)

### DIFF
--- a/src/main/java/org/jfairy/Fairy.java
+++ b/src/main/java/org/jfairy/Fairy.java
@@ -17,9 +17,27 @@ import org.jfairy.producer.text.Text;
 
 import java.io.IOException;
 import java.util.Locale;
+import java.util.Random;
 
 /**
- * Entry class
+ * <p>An object that generates random personal data.</p>
+ *
+ * <p>Using a {@link #builder()}, you can configure the following fields:</p>
+ * <ul>
+ *     <li><tt>locale</tt>: Specifies the locale for the random data file.</li>
+ *     <li><tt>filePrefix</tt>: Specifies the file prefix.
+ *         (So if you specify "fairyland" here and English for Locale, the data file will be
+ *         "fairyland_en.yml" under the classpath.)
+ *     </li>
+ *     <li><tt>random</tt>: The Random object to use.</li>
+ *     <li><tt>randomSeed</tt>: A specific random seed to use. Use this if you want the resulting
+ *         data to be <strong>deterministic</strong> based on it, such as if you want the same test
+ *         ID in a database to always result in the same fake name.
+ *     </li>
+ * </ul>
+ *
+ * Obviously, don't set both <tt>random</tt> and <tt>randomSeed</tt>, only the last one you set will
+ * actually take effect.
  */
 public final class Fairy {
 
@@ -27,8 +45,8 @@ public final class Fairy {
 
 	private final Injector injector;
 
-	private Fairy(Locale locale, String filePrefix) {
-		injector = Guice.createInjector(new FairyModule());
+	private Fairy(Locale locale, String filePrefix, Random random) {
+		injector = Guice.createInjector(new FairyModule(random));
 
 		try {
 			DataMaster dataMaster = injector.getInstance(DataMaster.class);
@@ -37,40 +55,105 @@ public final class Fairy {
 		} catch (IOException e) {
 			throw new IllegalStateException(e);
 		}
-
 	}
 
-	/**
-	 * Use this factory method to create dataset containing default fairyland.yml and fairyland_{langCode}.yml files
-	 * merged with custom files with the same name
-	 *
-	 * @return Fairy instance
-	 */
-	public static Fairy create() {
-		return create(Locale.ENGLISH);
-	}
+    public static class Builder {
+        private Locale locale = Locale.ENGLISH;
+        private String filePrefix = DATA_FILE_PREFIX;
+        private Random random = new Random();
 
-	/**
-	 * Use this factory method to create dataset containing default fairyland.yml and fairyland_{langCode}.yml files
-	 * merged with custom files with the same name
-	 *
-	 * @param locale will be used to assess langCode for data file
-	 * @return Fairy instance
-	 */
-	public static Fairy create(Locale locale) {
-		return create(locale, DATA_FILE_PREFIX);
-	}
+        private Builder() {}
 
-	/**
-	 * Use this factory method to create your own dataset overriding bundled one
-	 *
-	 * @param locale         will be used to assess langCode for data file
-	 * @param dataFilePrefix prefix of the data file - final pattern will be fairyland.yml and dataFilePrefix_{langCode}.yml
-	 * @return Fairy instance
-	 */
-	public static Fairy create(Locale locale, String dataFilePrefix) {
-		return new Fairy(locale, dataFilePrefix);
-	}
+        /**
+         * Sets the locale for the resulting Fairy.
+         * @param locale The Locale to set.
+         * @return the same Builder (for chaining).
+         */
+        public Builder withLocale(Locale locale) {
+            this.locale = locale;
+            return this;
+        }
+
+        /**
+         * Sets the data file prefix for the resulting Fairy.
+         * @param filePrefix The prefix of the file (such as "fairyland" for "fairyland_en.yml").
+         * @return the same Builder (for chaining).
+         */
+        public Builder withFilePrefix(String filePrefix) {
+            this.filePrefix = filePrefix;
+            return this;
+        }
+
+        /**
+         * Sets the Random object to use to pick things randomly.
+         * @param random The Random to use.
+         * @return the same Builder (for chaining).
+         */
+        public Builder withRandom(Random random) {
+            this.random = random;
+            return this;
+        }
+
+        /**
+         * Sets the random seed to use to pick things randomly. (If you set this, you will always
+         * get the same result when you generate things.)
+         * @param randomSeed The random seed to use.
+         * @return the same Builder (for chaining).
+         */
+        public Builder withRandomSeed(long randomSeed) {
+            this.random = new Random(randomSeed);
+            return this;
+        }
+
+        /**
+         * Returns the completed Fairy.
+         */
+        public Fairy build() {
+            return new Fairy(locale, filePrefix, random);
+        }
+    }
+
+    /**
+     * Creates a Builder that will let you configure a Fairy's fields one by one.
+     * @return a Builder instance.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Use this factory method to create dataset containing default fairyland.yml and fairyland_{langCode}.yml files
+     * merged with custom files with the same name
+     *
+     * @return Fairy instance
+     */
+    public static Fairy create() {
+        return builder().build();
+    }
+
+    /**
+     * Use this factory method to create dataset containing default fairyland.yml and fairyland_{langCode}.yml files
+     * merged with custom files with the same name
+     *
+     * @param locale will be used to assess langCode for data file
+     * @return Fairy instance
+     */
+    public static Fairy create(Locale locale) {
+        return builder().withLocale(locale).build();
+    }
+
+    /**
+     * Use this factory method to create your own dataset overriding bundled one
+     *
+     * @param locale         will be used to assess langCode for data file
+     * @param dataFilePrefix prefix of the data file - final pattern will be fairyland.yml and dataFilePrefix_{langCode}.yml
+     * @return Fairy instance
+     */
+    public static Fairy create(Locale locale, String dataFilePrefix) {
+        return builder().withLocale(locale)
+                        .withFilePrefix(dataFilePrefix)
+                        .build();
+    }
 
 	/**
 	 * Use this method for generating texts

--- a/src/main/java/org/jfairy/FairyModule.java
+++ b/src/main/java/org/jfairy/FairyModule.java
@@ -8,14 +8,23 @@ import org.jfairy.producer.person.NationalIdentityCardNumber;
 import org.jfairy.producer.person.locale.pl.Pesel;
 import org.jfairy.producer.person.locale.pl.PolishIdentityCardNumber;
 
+import java.util.Random;
+
 /**
  * @author jkubrynski@gmail.com
  * @since 2013-11-15
  */
 class FairyModule extends AbstractModule {
 
+    private final Random random;
+
+    public FairyModule(Random random) {
+        this.random = random;
+    }
+
 	@Override
 	protected void configure() {
+        bind(Random.class).toInstance(random);
 		bind(NationalIdentificationNumber.class).to(Pesel.class);
 		bind(NationalIdentityCardNumber.class).to(PolishIdentityCardNumber.class);
 		bind(VATIdentificationNumber.class).to(NIP.class);

--- a/src/main/java/org/jfairy/producer/BaseProducer.java
+++ b/src/main/java/org/jfairy/producer/BaseProducer.java
@@ -1,11 +1,13 @@
 package org.jfairy.producer;
 
 import com.google.common.base.Preconditions;
+import com.google.inject.Inject;
 
-import javax.inject.Singleton;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
+
+import javax.inject.Singleton;
 
 import static java.util.Collections.shuffle;
 
@@ -14,8 +16,9 @@ public class BaseProducer {
 
 	private final Random random;
 
-	public BaseProducer() {
-		this.random = new Random();
+	@Inject
+	public BaseProducer(Random random) {
+		this.random = random;
 	}
 
 	/**

--- a/src/test/groovy/org/jfairy/FairySpec.groovy
+++ b/src/test/groovy/org/jfairy/FairySpec.groovy
@@ -24,4 +24,35 @@ class FairySpec extends Specification {
 		then:
 		person.fullName() != old(person.fullName())
 	}
+
+    def "Second person should be the same with the same random seed"() {
+
+        given:
+        def firstFairy = Fairy.builder().withRandomSeed(10).build()
+        def secondFairy = Fairy.builder().withRandomSeed(10).build()
+
+        def firstPerson = firstFairy.person()
+        def secondPerson = secondFairy.person()
+        def thirdPerson = firstFairy.person()
+        def fourthPerson = secondFairy.person()
+
+        expect:
+        firstPerson.fullName().equals(secondPerson.fullName())
+        thirdPerson.fullName().equals(fourthPerson.fullName())
+
+        !firstPerson.fullName().equals(thirdPerson.fullName())
+    }
+
+    def "Second person should be different with different random seeds"() {
+
+        given:
+        def firstFairy = Fairy.builder().withRandomSeed(10).build()
+        def secondFairy = Fairy.builder().withRandomSeed(20).build()
+
+        def firstPerson = firstFairy.person()
+        def secondPerson = secondFairy.person();
+
+        expect:
+        !firstPerson.fullName().equals(secondPerson.fullName())
+    }
 }

--- a/src/test/groovy/org/jfairy/data/DataMasterSpec.groovy
+++ b/src/test/groovy/org/jfairy/data/DataMasterSpec.groovy
@@ -10,7 +10,7 @@ import spock.lang.Specification
 
 class DataMasterSpec extends Specification {
 
-	def baseProducer = Spy(BaseProducer);
+	def baseProducer = Spy(BaseProducer, constructorArgs: [new Random()]);
 	def data = Spy(DataMaster, constructorArgs: [baseProducer])
 
 	def setup() {

--- a/src/test/groovy/org/jfairy/producer/BaseProducerSpec.groovy
+++ b/src/test/groovy/org/jfairy/producer/BaseProducerSpec.groovy
@@ -9,7 +9,7 @@ import spock.lang.Unroll
 
 class BaseProducerSpec extends Specification {
 
-	def baseProducer = Spy(BaseProducer);
+	def baseProducer = Spy(BaseProducer, constructorArgs: [new Random()]);
 
 	def setup() {
 		baseProducer.randomBetween('0', '9') >> '7'
@@ -41,7 +41,7 @@ class BaseProducerSpec extends Specification {
 	@Unroll
 	def "should generate random number from given range #from - #to"() {
 		setup:
-		def randomGenerator = new BaseProducer();
+		def randomGenerator = new BaseProducer(new Random());
 
 		expect:
 		def between = randomGenerator.randomBetween(from, to)

--- a/src/test/groovy/org/jfairy/producer/DateProducerSpec.groovy
+++ b/src/test/groovy/org/jfairy/producer/DateProducerSpec.groovy
@@ -23,7 +23,7 @@ class DateProducerSpec extends Specification {
 	private static final SOME_DATE_IN_THE_PAST_IN_MILLIS = SOME_DATE_IN_THE_PAST.getMillis()
 	private static final FIVE_YEARS_EARLIER_DATE_IN_MILLIS = FIVE_YEARS_EARLIER_DATE.getMillis()
 
-	private baseProducer = Spy(BaseProducer)
+	private baseProducer = Spy(BaseProducer, constructorArgs: [new Random()])
 	private timeProviderMock = Mock(TimeProvider)
 	private DateProducer sut = new DateProducer(baseProducer, timeProviderMock)
 

--- a/src/test/groovy/org/jfairy/producer/locale/pl/NIPSpec.groovy
+++ b/src/test/groovy/org/jfairy/producer/locale/pl/NIPSpec.groovy
@@ -14,7 +14,7 @@ import spock.lang.Unroll
  */
 class NIPSpec extends Specification {
 
-	def baseProducer = new BaseProducer()
+	def baseProducer = new BaseProducer(new Random())
 	def generator = new NIP(baseProducer)
 
 	@Unroll

--- a/src/test/groovy/org/jfairy/producer/net/NetworkSpec.groovy
+++ b/src/test/groovy/org/jfairy/producer/net/NetworkSpec.groovy
@@ -8,7 +8,7 @@ class NetworkSpec extends Specification {
 
 	def ipValidator = InetAddressValidator.getInstance();
 
-	def ipNumber = new IPNumber(new BaseProducer());
+	def ipNumber = new IPNumber(new BaseProducer(new Random()));
 	def network = new Network(ipNumber)
 
 	def "Should generate proper ip number"() {

--- a/src/test/groovy/org/jfairy/producer/payment/CreditCardProducerSpec.groovy
+++ b/src/test/groovy/org/jfairy/producer/payment/CreditCardProducerSpec.groovy
@@ -18,7 +18,7 @@ class CreditCardProducerSpec extends Specification {
 	private DateProducer dateProducer
 
 	def setup() {
-		dataMaster = new DataMaster(new BaseProducer())
+		dataMaster = new DataMaster(new BaseProducer(new Random()))
 		dateProducer = Mock(DateProducer)
 		dataMaster.readResources("fairyland.yml")
 	}


### PR DESCRIPTION
This commit adds the ability to set the random seed manually when instantiating a Fairy.

This allows you to make the results deterministic; this is useful if you want to get the same names every time you run a Fairy. Say, for example, you have a database of user IDs, but no PII stored with them. You want to create an internal interface that displays metadata about those users, but you don't want to see anything identifying. This allows you to use the user ID as a random seed, thereby _always getting the same fake name for each ID_ every time you load the interface.

(Once this is merged, can you tag and release this out? I need to implement this very use case. :))
