### PR TITLE
Remove compile/runtime dependency to groovy-all

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,11 +137,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.codehaus.groovy</groupId>
-			<artifactId>groovy-all</artifactId>
-			<version>2.4.14</version>
-		</dependency>
-		<dependency>
 			<groupId>org.spockframework</groupId>
 			<artifactId>spock-core</artifactId>
 			<version>1.1-groovy-2.4</version>


### PR DESCRIPTION
This results in a downgrade of groovy-all in test scope: 2.4.14 -> 2.4.9

Resolves #105