### PR TITLE
Handle ß in email addresses

### DIFF
--- a/src/main/java/com/devskiller/jfairy/producer/person/CompanyEmailProvider.java
+++ b/src/main/java/com/devskiller/jfairy/producer/person/CompanyEmailProvider.java
@@ -21,6 +21,7 @@ public class CompanyEmailProvider implements Provider<String> {
 
 	@Override
 	public String get() {
-		return TextUtils.stripAccents(lowerCase(firstName + '.' + lastName + '@' + company.getDomain())).replaceAll(" ", ".");
+		String email = lowerCase(firstName + '.' + lastName + '@' + company.getDomain()).replaceAll(" ", ".");
+		return TextUtils.stripSharpS(TextUtils.stripAccents(email));
 	}
 }

--- a/src/main/java/com/devskiller/jfairy/producer/person/EmailProvider.java
+++ b/src/main/java/com/devskiller/jfairy/producer/person/EmailProvider.java
@@ -39,6 +39,7 @@ public class EmailProvider implements Provider<String> {
 				prefix = StringUtils.replace(lastName, " ", "");
 				break;
 		}
-		return TextUtils.stripAccents(lowerCase(prefix + '@' + dataMaster.getRandomValue(PERSONAL_EMAIL)));
+		String email = lowerCase(prefix + '@' + dataMaster.getRandomValue(PERSONAL_EMAIL));
+		return TextUtils.stripSharpS(TextUtils.stripAccents(email));
 	}
 }

--- a/src/main/java/com/devskiller/jfairy/producer/util/TextUtils.java
+++ b/src/main/java/com/devskiller/jfairy/producer/util/TextUtils.java
@@ -21,4 +21,8 @@ public final class TextUtils {
 		return org.apache.commons.lang3.StringUtils.stripAccents(s).replaceAll("ł", "l").replaceAll("Ł", "L");
 	}
 
+	public static String stripSharpS(String s) {
+		return s.replace("\u00DF", "ss");
+	}
+
 }

--- a/src/test/groovy/com/devskiller/jfairy/producer/person/CompanyEmailProviderSpec.groovy
+++ b/src/test/groovy/com/devskiller/jfairy/producer/person/CompanyEmailProviderSpec.groovy
@@ -29,4 +29,16 @@ class CompanyEmailProviderSpec extends Specification {
 		then:
 			email == "aaoeaacelnsozz.aaoeaacelnsozz@aaoeaacelnsozz.com"
 	}
+
+	def "should strip sharp s from company email"() {
+		given:
+			Company company = new Company(null, "companymail.com", null, null);
+			CompanyEmailProvider companyEmailProvider = new CompanyEmailProvider("Thieß", "Weißmann", company);
+
+		when:
+			String email = companyEmailProvider.get();
+
+		then:
+			email == "thiess.weissmann@companymail.com"
+	}
 }

--- a/src/test/groovy/com/devskiller/jfairy/producer/person/EmailProviderSpec.groovy
+++ b/src/test/groovy/com/devskiller/jfairy/producer/person/EmailProviderSpec.groovy
@@ -63,4 +63,16 @@ class EmailProviderSpec extends Specification {
 		then:
 			email == "aaoeaacelnsozz.aaoeaacelnsozz@mail.com"
 	}
+
+	def "should strip sharp s from email"() {
+		given:
+			baseProducer.randomBetween(1, 3) >> 2
+			EmailProvider emailProvider = new EmailProvider(dataMaster, baseProducer, "Thieß", "Weißmann");
+
+		when:
+			String email = emailProvider.get();
+
+		then:
+			email == "thiess.weissmann@mail.com"
+	}
 }


### PR DESCRIPTION
From now on, the character ß is converted to ss in email addresses.

I kept the (maybe not perfect) code style to keep it consistent with the surrounded code base.

Resolves #112