### PR TITLE
fix: Fixed #111 with illegal chars in url

### DIFF
--- a/src/main/java/com/devskiller/jfairy/producer/net/NetworkProducer.java
+++ b/src/main/java/com/devskiller/jfairy/producer/net/NetworkProducer.java
@@ -27,13 +27,14 @@ public class NetworkProducer {
 	 */
 	public String url(boolean isHttps) {
 		String mergedIP = ipAddress().replaceAll("\\.", "");
-		char[] domainChars = mergedIP.toCharArray();
+		String[] domainChars = mergedIP.split("");
+
 		for (int i = 0; i < domainChars.length; i++) {
-			char c = domainChars[i];
-			domainChars[i] = (char) (c + 97);
+			int c = Integer.parseInt(domainChars[i]);
+			domainChars[i] = ((char) (c + 97)) + "";
 		}
 
-		String domain = String.valueOf(domainChars);
+		String domain = String.join("", domainChars);
 		if (isHttps) {
 			return "https://" + domain + ".com";
 		} else {


### PR DESCRIPTION
This PR fixed a #111 problem was how we handled this party:

```java
public String url(boolean isHttps) {
		String mergedIP = ipAddress().replaceAll("\\.", "");
		char[] domainChars = mergedIP.toCharArray();
		for (int i = 0; i < domainChars.length; i++) {
			char c = domainChars[i];
			domainChars[i] = (char) (c + 97);
		}

		String domain = String.valueOf(domainChars);
		if (isHttps) {
			return "https://" + domain + ".com";
		} else {
			return "http://" + domain + ".com";
		}
	}
```	

Array contains chars, but in `domainChars[i] = (char) (c + 97);` we do something like a get int value of **char**, add 97, and write back to array e.g. if we get char `1` we read int 49, add 97 and write back a char 146 that is "illegal".

We would like to tread that char `1` as int 1, add 97 and write back (char `b`). 

My change is to replace cast char to int into parse it to int.